### PR TITLE
Improve form types

### DIFF
--- a/src/main/useForm.ts
+++ b/src/main/useForm.ts
@@ -5,7 +5,7 @@ import { generateField } from './generateField'
 import { FieldConfig, GateField, InnerForm } from './types'
 
 type FormGateCallbacks<T> = {
-    onSuccess(form: T): void,
+    onSuccess(form: {[K in keyof T]: T[K] extends GateField<infer F> ? F : never}): void,
     onError?(form: Record<keyof T, string>): void
 }
 

--- a/src/main/useForm.ts
+++ b/src/main/useForm.ts
@@ -9,8 +9,8 @@ type FormGateCallbacks<T> = {
     onError?(form: Record<keyof T, string>): void
 }
 
-export function useForm<T>(
-    formFields: Record<keyof T, GateField<any>>,
+export function useForm<T extends Record<PropertyKey, GateField<any>>>(
+    formFields: T,
     callbacks: FormGateCallbacks<T>
 ) {
     const injectedForm = Object
@@ -18,7 +18,7 @@ export function useForm<T>(
         .reduce((acc, [key, value]) => ({
             ...acc,
             [key]: value
-        }), {}) as Record<keyof T, GateField<any>>
+        }), {}) as {[K in keyof T]: T[K]}
     const [innerForm, setInnerForm] = useState<InnerForm<T>>({} as InnerForm<T>)
     const innerFormRef = useRef(innerForm)
     const form = {


### PR DESCRIPTION
Previously every Field type was ``any`` and you needed to manually set correct form types, now useForm hook correctly infers those types

![screen](https://user-images.githubusercontent.com/48803618/222233805-1a121b11-13ea-4f25-85e9-d81476d57d00.png)
