### PR TITLE
Fix form keys typing mismatch

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,18 +5,17 @@ type ValidationRule<T> = {
     validate(value: T): boolean
 }
 
-type Field<T, Required extends boolean = boolean> = {
+type Field<T, TRequired extends boolean = boolean> = {
     value: T,
-    key: string,
     label?: string,
-    isRequired: Required,
+    isRequired: TRequired,
     hasChange: boolean,
     placeholder?: string,
     errorMessage: string,
     onBlur: VoidFunction,
     resetState: VoidFunction,
     validate: VoidFunction,
-    children?: Array<Field<T>>,
+    children?: Array<ChildrenField<T>>,
     hasError: boolean,
     validateOnSubmit(): string,
     onChangeValue(newValue: T): void,
@@ -24,8 +23,11 @@ type Field<T, Required extends boolean = boolean> = {
     setError(errorMessage: string): void
 }
 
+type ChildrenField<T, TRequired extends boolean = boolean> = Field<T, TRequired> & {
+    key: string
+}
+
 export type FieldConfig<T, Required extends boolean = boolean> = {
-    key: string,
     label?: string,
     initialValue: T,
     isRequired: Required,
@@ -34,6 +36,10 @@ export type FieldConfig<T, Required extends boolean = boolean> = {
     validationRules?: Array<ValidationRule<T>>,
     liveParser?(value: T): T,
     submitParser?(value: T): T
+}
+
+export type ChildrenFieldConfig<T, Required extends boolean = boolean> = FieldConfig<T, Required> & {
+    key: string
 }
 
 // ...args: Array<any> - otherwise typescript throws an error when we pass parameters into config function
@@ -59,9 +65,9 @@ type UseFormReturn<T extends Record<PropertyKey, Field<any> | undefined>> = {
     validateAll(): boolean,
     formHasChanges(): boolean,
     setError(field: string, errorMessage: string): void,
-    setFieldValue<K extends keyof T | string>(field: K, value: K extends keyof T ? FieldValue<T, K> : any): void,
-    setFieldInitialValue<K extends keyof T | string>(field: K, value: K extends keyof T ? FieldValue<T, K> : any): void,
-    addFields(fields: Array<FieldConfig<any>>): void,
+    setFieldValue<K extends keyof T | (string & {})>(field: K, value: K extends keyof T ? FieldValue<T, K> : any): void,
+    setFieldInitialValue<K extends keyof T | (string & {})>(field: K, value: K extends keyof T ? FieldValue<T, K> : any): void,
+    addFields(fields: Array<ChildrenFieldConfig<any>>): void,
     removeFieldIds(fields: Array<string>): void
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "author": "@codegate",
     "license": "MIT",
     "typings": "index.d.ts",
-    "version": "1.2.24",
+    "version": "1.3.0",
     "main": "dist/index.js",
     "scripts": {
         "tsc": "node node_modules/typescript/bin/tsc",

--- a/src/main/generateField.ts
+++ b/src/main/generateField.ts
@@ -1,5 +1,4 @@
 import { isEmpty } from 'ramda'
-import { R } from '../lib/utils'
 import { ExtendedConfig, FieldConfig, GateFieldState } from './types'
 
 type GenerateFieldProps<T> = {
@@ -133,5 +132,5 @@ export const generateField = <T>({
 
             return hasError
         }
-    } as ExtendedConfig<T>
+    } as unknown as ExtendedConfig<T>
 }

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -14,22 +14,19 @@ export type GateFieldState<T> = {
 }
 
 export type FieldConfig<T> = {
-    key: string,
     label?: string,
     initialValue?: T,
     isRequired?: boolean,
     placeholder?: string,
     validateOnBlur?: boolean,
     validationRules?: Array<ValidationRule<T>>,
-    children?: Array<FieldConfig<T>>,
+    children?: Array<ChildrenFieldConfig<T>>,
     liveParser?(value: T): T,
     submitParser?(value: T): T
 }
 
-export type FormFieldLike = {
-    value: any,
-    isRequired: boolean,
-    errorMessage: string
+export type ChildrenFieldConfig<T> = FieldConfig<T> & {
+    key: string
 }
 
 type ValidateOnSubmitProps = {
@@ -39,7 +36,6 @@ type ValidateOnSubmitProps = {
 
 export type GateField<T> = {
     value: T | string,
-    key: string,
     label?: string,
     isRequired: boolean,
     hasChange: boolean,
@@ -57,12 +53,8 @@ export type GateField<T> = {
     setError(errorMessage: string): void
 }
 
-export type SinglePickerOption = {
-    key: string,
-    value: any
-}
-
 export type ExtendedConfig<T> = GateField<T> & {
+    key: string,
     localInitialValue: T,
     isPristine: boolean,
     validationRules: Array<ValidationRule<T>>,

--- a/src/tests/useField.test.ts
+++ b/src/tests/useField.test.ts
@@ -90,7 +90,6 @@ describe('useField', () => {
     testsCases.forEach(testCase => {
         test(JSON.stringify(testCase), () => {
             const { result } = renderHook(() => useField({
-                key: 'test',
                 initialValue: '',
                 isRequired: testCase.required,
                 validateOnBlur: testCase.validateOnBlur,
@@ -117,7 +116,6 @@ describe('useField', () => {
 
     test('Test if field gets pristine after correct value has been passed', () => {
         const { result } = renderHook(() => useField({
-            key: 'test',
             initialValue: '',
             isRequired: true,
             validateOnBlur: true,

--- a/src/tests/useForm.test.ts
+++ b/src/tests/useForm.test.ts
@@ -101,7 +101,6 @@ describe('useForm - isFilled', () => {
         test(JSON.stringify(testCase), () => {
             const { isRequired, initialValue } = testCase.fieldConfig
             const { result: field } = renderHook(() => useField({
-                key: 'test',
                 initialValue,
                 isRequired
             }))
@@ -122,14 +121,12 @@ describe('useForm - isFilled', () => {
 describe('useForm - submit form', () => {
     const useConfig = () => {
         const field = useField({
-            key: 'field',
             initialValue: '',
             isRequired: true,
             validationRules: [ rules.empty ]
         })
 
         const nonRequired = useField({
-            key: 'nonRequired',
             initialValue: '',
             isRequired: false,
             validationRules: [ rules.empty ]


### PR DESCRIPTION
If we've passed key to ``useField`` hook, that is not the same as key of object that is passed to ``useForm`` hook
example:
```ts

const useConfig = () => {
    const test = useField({
        key: 'differentKey',
        initialValue: '',
        isRequired: true
    })

    return {
        test
    }
}

const { form, setFieldValue, addFields } = useForm(useConfig(), {
    onSuccess: () => {}
})

form.test
// ✅
form.differentKey
// ❌ - typescript infered type from test so it doesn't know that "differentKey" is correct, and "test" will be undefined here

```

Typescript will be having ``form.test`` field which is incorrect because we were using "key" prop from useField to determine keys that are in form object returned from ``useForm`` hook

## Proposal

- removed key property from useField
- key property stays when we want to add dynamic fields

![image](https://github.com/codemaskinc/react-form-builder-v2/assets/48803618/05827596-0bc7-47eb-ba36-13ccb0e78548)

