### PR TITLE
Improve typings for development

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,10 @@
+export declare global {
+  interface ObjectConstructor extends globalThis.ObjectConstructor {
+      keys<TObj>(object: TObj): Array<keyof TObj>,
+      entries<TObj>(object: TObj): Array<[keyof TObj, TObj[keyof TObj]]>
+  }
+
+  interface Array<T> {
+      includes(searchElement: any, fromIndex?: number): searchElement is T
+  }
+}

--- a/src/main/generateField.ts
+++ b/src/main/generateField.ts
@@ -46,14 +46,15 @@ export const generateField = <T>({
 
     return {
         ...fieldConfig,
-        value: field?.value ?? fieldConfig.initialValue,
+        validationRules: fieldConfig.validationRules ?? [],
+        value: field?.value ?? fieldConfig.initialValue as T,
         hasChange: field?.value !== field?.localInitialValue,
         isPristine: field?.isPristine ?? true,
         parentKey,
         hasError: field?.hasError ?? false,
         isRequired: fieldConfig.isRequired ?? false,
         validateOnBlur: fieldConfig.validateOnBlur ?? false,
-        localInitialValue: fieldConfig.initialValue ?? '',
+        localInitialValue: fieldConfig.initialValue ?? '' as T,
         errorMessage: field?.errorMessage ?? '',
         onChangeValue: (value: T) => setField(prevState => {
             const newValue = fieldConfig.liveParser

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -54,11 +54,18 @@ export type GateField<T> = {
 }
 
 export type ExtendedConfig<T> = GateField<T> & {
-    key: string,
     localInitialValue: T,
     isPristine: boolean,
     validationRules: Array<ValidationRule<T>>,
     validateOnBlur: boolean
 }
 
-export type InnerForm<T> = Record<string, ExtendedConfig<T>>
+export type Form = Record<PropertyKey, GateField<any>>
+
+export type InnerForm<T extends Form> = {[K in keyof T]: ExtendedConfig<T[K]['value']>}
+
+export type DynamicForm<T extends Form> = T & Partial<Form>
+
+type ExtractGateField<T> = T extends GateField<infer V> ? V : never
+
+export type ExtractForm<T extends Form> = {[K in keyof T]: ExtractGateField<T[K]>}


### PR DESCRIPTION
Types that are included in package ``index.d.ts`` are in pretty good condition now, but typings when we are developing library are in a little mess. There are some ``any``, ``{}`` and unnecessary passing types into generics. Which makes everything pretty hard to read and edit

This change doesn't need to be published to npm