### PR TITLE
fix: onchange to undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "author": "@codegate",
     "license": "MIT",
     "typings": "index.d.ts",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "main": "dist/index.js",
     "scripts": {
         "tsc": "node node_modules/typescript/bin/tsc",

--- a/src/main/generateField.ts
+++ b/src/main/generateField.ts
@@ -47,7 +47,7 @@ export const generateField = <T>({
     return {
         ...fieldConfig,
         validationRules: fieldConfig.validationRules ?? [],
-        value: field?.value ?? fieldConfig.initialValue,
+        value: field ? field.value : fieldConfig.initialValue,
         hasChange: field?.value !== field?.localInitialValue,
         isPristine: field?.isPristine ?? true,
         parentKey,


### PR DESCRIPTION
If we for example have initial value set to ``[]`` and we want to change it to undefined, it will fallback to initialValue